### PR TITLE
fix: B2B Orders sometimes not showing after checkout

### DIFF
--- a/lib/b2b/open-orders.js
+++ b/lib/b2b/open-orders.js
@@ -139,7 +139,7 @@ async function loadOpenOrders({ arDivisionNo, customerNo, salesOrderNo, userId }
                              WHERE (userid = :userId OR api_id = :api_id)) AS a
                                 INNER JOIN c2.SO_SalesOrderHeader h
                                            ON a.Company = h.Company AND a.ARDivisionNo = h.ARDivisionNo AND
-                                              a.CustomerNo = h.CustomerNo AND a.ShipToCode = h.ShipToCode
+                                              a.CustomerNo = h.CustomerNo AND a.ShipToCode = ifnull(h.ShipToCode, '')
                                 LEFT JOIN c2.ar_termscode tc
                                           ON tc.Company = h.Company AND tc.TermsCode = h.TermsCode
                                 LEFT JOIN c2.sy_user u

--- a/lib/b2b/open-orders.ts
+++ b/lib/b2b/open-orders.ts
@@ -152,7 +152,7 @@ async function loadOpenOrders({arDivisionNo, customerNo, salesOrderNo, userId}:L
                              WHERE (userid = :userId OR api_id = :api_id)) AS a
                                 INNER JOIN c2.SO_SalesOrderHeader h
                                            ON a.Company = h.Company AND a.ARDivisionNo = h.ARDivisionNo AND
-                                              a.CustomerNo = h.CustomerNo AND a.ShipToCode = h.ShipToCode
+                                              a.CustomerNo = h.CustomerNo AND a.ShipToCode = ifnull(h.ShipToCode, '')
                                 LEFT JOIN c2.ar_termscode tc
                                           ON tc.Company = h.Company AND tc.TermsCode = h.TermsCode
                                 LEFT JOIN c2.sy_user u


### PR DESCRIPTION
- found that sometimes ShipToCode is null after checkout, so linked the table SO_SalesOrderHeader using ifnull(h.ShipToCode, '')...